### PR TITLE
Change dependent limit of rails

### DIFF
--- a/wice_grid.gemspec
+++ b/wice_grid.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.date          = `date +%Y-%m-%d`
 
-  s.add_dependency 'rails', '~> 7.0'
+  s.add_dependency 'rails', '>= 7.0'
   s.add_dependency 'kaminari'
   s.add_dependency 'jquery-rails'
 


### PR DESCRIPTION
## 概要
Rails 8.0に対応できるようにするため、Rails gemのバージョン依存性を変更しました。

## 行ったこと
- railsのバージョン依存を7.0以上に変更